### PR TITLE
chore(deps): update grafana/grafana docker tag to v4.6.5

### DIFF
--- a/performance/docker-compose.yml
+++ b/performance/docker-compose.yml
@@ -10,7 +10,7 @@ services:
   #   volumes:
   #         - ./sitespeed-result/:/sitespeed.io/sitespeed-result
   grafana:
-    image: grafana/grafana:4.1.1
+    image: grafana/grafana:4.6.5
     depends_on:
       - graphite
     links:


### PR DESCRIPTION
| datasource | package         | from  | to    |
| ---------- | --------------- | ----- | ----- |
| docker     | grafana/grafana | 4.1.1 | 4.6.5 |